### PR TITLE
refactor(cli): remove powerup edition option

### DIFF
--- a/bin/pagezero.ts
+++ b/bin/pagezero.ts
@@ -8,14 +8,8 @@ program
   .description("PageZERO CLI")
   .option("-h, --help", "output usage information")
 
-program
-  .command("init")
-  .description("initialize a new project")
-  .action(init)
+program.command("init").description("initialize a new project").action(init)
 
-program
-  .command("upgrade")
-  .description("upgrade pagezero stack")
-  .action(upgrade)
+program.command("upgrade").description("upgrade pagezero stack").action(upgrade)
 
 program.parse()

--- a/bin/pagezero.ts
+++ b/bin/pagezero.ts
@@ -11,13 +11,11 @@ program
 program
   .command("init")
   .description("initialize a new project")
-  .option("-p, --powerup", "use PowerUP edition")
   .action(init)
 
 program
   .command("upgrade")
   .description("upgrade pagezero stack")
-  .option("-p, --powerup", "use PowerUP edition")
   .action(upgrade)
 
 program.parse()

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import { $, file, write } from "bun"
 import chalk from "chalk"
 import { spinner } from "../utils"
 
-export async function init({ powerup }: { powerup?: boolean }) {
+export async function init() {
   // Welcome
   console.log(chalk.green("👋 Welcome to PageZERO CLI"))
   console.log(chalk.green("🚀 Let's get you started with your project!"))
@@ -12,15 +12,9 @@ export async function init({ powerup }: { powerup?: boolean }) {
   const projectName = await input({
     message: "What is the name of your project?",
   })
-  if (powerup) {
-    await spinner("downloading pagezero powerup edition", async () => {
-      await $`git clone --depth 1 https://github.com/pagezero-dev/powerup.git ${projectName}`.quiet()
-    })
-  } else {
-    await spinner("downloading pagezero", async () => {
-      await $`git clone --depth 1 https://github.com/pagezero-dev/pagezero.git ${projectName}`.quiet()
-    })
-  }
+  await spinner("downloading pagezero", async () => {
+    await $`git clone --depth 1 https://github.com/pagezero-dev/pagezero.git ${projectName}`.quiet()
+  })
 
   // Install dependencies
   await spinner(`running: bun install`, () =>

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import chalk from "chalk"
 import logSymbols from "log-symbols"
 import { spinner } from "../utils"
 
-export async function upgrade({ powerup }: { powerup?: boolean }) {
+export async function upgrade() {
   console.log(
     chalk.yellow(
       boxen(
@@ -43,15 +43,9 @@ export async function upgrade({ powerup }: { powerup?: boolean }) {
     return
   }
 
-  if (powerup) {
-    await spinner(`downloading latest PageZERO PowerUP edition`, () =>
-      $`git clone --depth 1 https://github.com/pagezero-dev/powerup.git pagezero-latest`.quiet(),
-    )
-  } else {
-    await spinner(`downloading latest PageZERO stack`, () =>
-      $`git clone --depth 1 https://github.com/pagezero-dev/pagezero.git pagezero-latest`.quiet(),
-    )
-  }
+  await spinner(`downloading latest PageZERO stack`, () =>
+    $`git clone --depth 1 https://github.com/pagezero-dev/pagezero.git pagezero-latest`.quiet(),
+  )
 
   await spinner(`copying PageZERO stack to project directory`, () =>
     $`rsync -a --exclude=".git" ./pagezero-latest/ ./`.quiet(),


### PR DESCRIPTION
## Summary
- Remove `-p` / `--powerup` from `init` and `upgrade` subcommands
- Always clone and upgrade from the standard `pagezero-dev/pagezero` repository


Made with [Cursor](https://cursor.com)