### PR TITLE
refactor(cli): delegate wrangler.json config to setup:wrangler script

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,5 @@
 import { input } from "@inquirer/prompts"
-import { $, file, write } from "bun"
+import { $ } from "bun"
 import chalk from "chalk"
 import { spinner } from "../utils"
 
@@ -26,21 +26,10 @@ export async function init() {
     $`bun run setup`.quiet().cwd(projectName),
   )
 
-  // Update wrangler.json
-  await spinner(`updating wrangler.json`, async () => {
-    const wranglerJson = await file(`${projectName}/wrangler.json`).json()
-    wranglerJson.name = projectName
-    wranglerJson.d1_databases[0].database_name = `${projectName}-development`
-    wranglerJson.env.production.d1_databases[0].database_name = `${projectName}-production`
-    wranglerJson.env.preview.d1_databases[0].database_name = `${projectName}-preview`
-    wranglerJson.env.test.d1_databases[0].database_name = `${projectName}-test`
-    wranglerJson.env.production.d1_databases[0].database_id = "<DATABASE_ID>"
-    wranglerJson.env.preview.d1_databases[0].database_id = "<DATABASE_ID>"
-    await write(
-      `${projectName}/wrangler.json`,
-      JSON.stringify(wranglerJson, null, 2),
-    )
-  })
+  // Configure wrangler.json
+  await spinner(`configuring wrangler.json`, async () =>
+    $`bun run setup:wrangler`.quiet().cwd(projectName),
+  )
 
   // Initialize git repository
   await spinner("initializing fresh git repository", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,9 +27,10 @@ export async function init() {
   )
 
   // Configure wrangler.json
-  await spinner(`configuring wrangler.json`, async () =>
-    $`bun run setup:wrangler`.quiet().cwd(projectName),
-  )
+  await spinner(`configuring wrangler.json`, async () => {
+    await $`bun run setup:wrangler`.quiet().cwd(projectName)
+    await $`bun run check:fix`.quiet().cwd(projectName)
+  })
 
   // Initialize git repository
   await spinner("initializing fresh git repository", async () => {


### PR DESCRIPTION
## Summary
- Replace inline `wrangler.json` manipulation in the `init` command with a call to the project's `setup:wrangler` script
- Remove unused `file` and `write` imports from Bun

## Test plan
- [ ] Run `init` against a fresh project and verify `wrangler.json` is configured correctly
- [ ] Confirm `bun run setup:wrangler` runs successfully in the generated project directory


Made with [Cursor](https://cursor.com)