### PR TITLE
fix(init): remove redundant check:fix from wrangler setup

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -29,7 +29,6 @@ export async function init() {
   // Configure wrangler.json
   await spinner(`configuring wrangler.json`, async () => {
     await $`bun run setup:wrangler`.quiet().cwd(projectName)
-    await $`bun run check:fix`.quiet().cwd(projectName)
   })
 
   // Initialize git repository


### PR DESCRIPTION
## Summary
- Remove the `bun run check:fix` step from the wrangler configuration phase of `init`
- Wrangler setup is already handled by `setup:wrangler`, so running `check:fix` during project bootstrap was redundant

## Test plan
- [ ] Run `init` and confirm the wrangler configuration step completes without invoking `check:fix`
- [ ] Verify the generated project still has a valid `wrangler.json` after init


Made with [Cursor](https://cursor.com)