### PR TITLE
fix(upgrade): sync project with rsync --delete and exclude node_modules

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -9,7 +9,11 @@ export async function upgrade() {
   console.log(
     chalk.yellow(
       boxen(
-        "Ugrade command is primitive. It will overwrite your existing \nproject files with the latest version of the PageZERO stack. \nAfterwards please review the changes through a git diff.",
+        "Upgrade syncs your project with the latest PageZERO stack.\n\n" +
+          "• Existing stack files will be overwritten\n" +
+          "• Files removed from the stack will be deleted from your project\n" +
+          "• node_modules and .git are left untouched\n\n" +
+          "Review the result with git diff before committing.",
         { padding: 1, title: "WARNING", titleAlignment: "center" },
       ),
     ),

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -47,8 +47,8 @@ export async function upgrade() {
     $`git clone --depth 1 https://github.com/pagezero-dev/pagezero.git pagezero-latest`.quiet(),
   )
 
-  await spinner(`copying PageZERO stack to project directory`, () =>
-    $`rsync -a --exclude=".git" ./pagezero-latest/ ./`.quiet(),
+  await spinner(`syncing PageZERO stack with project directory`, () =>
+    $`rsync -a --delete --exclude=".git" --exclude="node_modules" ./pagezero-latest/ ./`.quiet(),
   )
 
   await spinner(`cleaning up`, () => $`rm -rf pagezero-latest`.quiet())

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -48,7 +48,7 @@ export async function upgrade() {
   )
 
   await spinner(`syncing PageZERO stack with project directory`, () =>
-    $`rsync -a --delete --exclude=".git" --exclude="node_modules" ./pagezero-latest/ ./`.quiet(),
+    $`rsync -a --delete --exclude=".git" --exclude="node_modules" --exclude="pagezero-latest" ./pagezero-latest/ ./`.quiet(),
   )
 
   await spinner(`cleaning up`, () => $`rm -rf pagezero-latest`.quiet())


### PR DESCRIPTION
## Summary
- Use `rsync --delete` during upgrade so files removed from the upstream PageZERO stack are also removed from the project
- Exclude `node_modules` from sync to preserve locally installed dependencies
- Update spinner message to reflect sync behavior

## Test plan
- [ ] Run `upgrade` in a PageZERO project and confirm files are synced correctly
- [ ] Verify `node_modules` is left untouched after upgrade
- [ ] Verify files removed upstream are deleted from the project after upgrade


Made with [Cursor](https://cursor.com)